### PR TITLE
opencti.contracts is a list

### DIFF
--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -94,7 +94,7 @@ impl Settings {
         config_builder
             .add_source(File::with_name("config/default"))
             .add_source(File::with_name(&format!("config/{}", run_mode)).required(false))
-            .add_source(Environment::default().try_parsing(true).separator("_"))
+            .add_source(Environment::default().list_separator(",").with_list_parse_key("opencti.contracts").try_parsing(true).separator("_"))
             .build()?
             .try_deserialize()
     }


### PR DESCRIPTION
it seems that there is no standard way to handle list/arrays when using environment variables for configuration.
Since opencti.contracts (and obas.contracts which is missing there) is a list, it needs to be treated so when using environment variables.

At Filigran we can switch to configmaps but if using  env variables is an option then it must be supported anyway

this PR works but untested with a single contract item (used /dev/null,dev/contracts/opencti-contracts.json)

