### PR TITLE
[composer] Prevent crash when backend lacks XTM Composer support

### DIFF
--- a/src/api/opencti/error_handler.rs
+++ b/src/api/opencti/error_handler.rs
@@ -1,0 +1,54 @@
+use cynic::GraphQlResponse;
+use tracing::error;
+
+/// Generic error handler for GraphQL responses
+/// Returns the data if successful, None if there are errors or no data
+pub fn handle_graphql_response<T>(
+    response: GraphQlResponse<T>,
+    operation_name: &str,
+    unsupported_message: &str,
+) -> Option<T> {
+    // Check for GraphQL errors first
+    let query_errors = response.errors.unwrap_or_default();
+    if !query_errors.is_empty() {
+        let errors: Vec<String> = query_errors.iter().map(|err| err.to_string()).collect();
+        error!(
+            error = errors.join(","),
+            operation = operation_name,
+            "GraphQL operation failed"
+        );
+        return None;
+    }
+
+    // Check if data is present
+    match response.data {
+        Some(data) => Some(data),
+        None => {
+            error!(
+                operation = operation_name,
+                "{}",
+                unsupported_message
+            );
+            None
+        }
+    }
+}
+
+/// Helper to extract a nested optional field with error handling
+pub fn extract_optional_field<T>(
+    field: Option<T>,
+    field_name: &str,
+    operation_name: &str,
+) -> Option<T> {
+    match field {
+        Some(value) => Some(value),
+        None => {
+            error!(
+                operation = operation_name,
+                field = field_name,
+                "OpenCTI backend returned null for field"
+            );
+            None
+        }
+    }
+}

--- a/src/api/opencti/manager/post_register.rs
+++ b/src/api/opencti/manager/post_register.rs
@@ -1,5 +1,6 @@
 use crate::api::opencti::ApiOpenCTI;
 use crate::api::opencti::manager::ConnectorManager;
+use crate::api::opencti::error_handler::{handle_graphql_response, extract_optional_field};
 use crate::api::opencti::opencti as schema;
 use cynic;
 use tracing::{error, info};
@@ -41,16 +42,18 @@ pub async fn register(api: &ApiOpenCTI) {
     let mutation_response = api.query_fetch(mutation).await;
     match mutation_response {
         Ok(response) => {
-            let query_errors = response.errors.unwrap_or_default();
-            if !query_errors.is_empty() {
-                let errors: Vec<String> = query_errors.iter().map(|err| err.to_string()).collect();
-                error!(
-                    error = errors.join(","),
-                    "Error registering connector manager"
-                );
-            } else {
-                let data = response.data.unwrap().register_connectors_manager.unwrap();
-                info!(manager_id = data.id.into_inner(), "Manager registered");
+            if let Some(data) = handle_graphql_response(
+                response,
+                "register_connectors_manager",
+                "OpenCTI backend does not support XTM composer manager registration. The composer will continue to run but won't be registered in OpenCTI."
+            ) {
+                if let Some(manager) = extract_optional_field(
+                    data.register_connectors_manager,
+                    "register_connectors_manager",
+                    "register_connectors_manager"
+                ) {
+                    info!(manager_id = manager.id.into_inner(), "Manager registered");
+                }
             }
         }
         Err(e) => {

--- a/src/api/opencti/mod.rs
+++ b/src/api/opencti/mod.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 
 pub mod connector;
 pub mod manager;
+pub mod error_handler;
 
 const BEARER: &str = "Bearer";
 const AUTHORIZATION_HEADER: &str = "Authorization";


### PR DESCRIPTION
# XTM Composer GraphQL Error Handling Fix

## Problem
The XTM composer was crashing when the OpenCTI backend didn't support XTM composer operations, specifically when GraphQL mutations returned `None` for the data field.

## Solution
Implemented a centralized error handler for all GraphQL responses to ensure consistent error handling across the application.

### New Error Handler Module
Created `src/api/opencti/error_handler.rs` with two main functions:
- `handle_graphql_response<T>()` - Handles GraphQL response errors and missing data
- `extract_optional_field<T>()` - Safely extracts optional fields with error logging

## Files Modified

### New File:
- `src/api/opencti/error_handler.rs` - Centralized error handling functions

### Updated Files:
- `src/api/opencti/mod.rs` - Added error_handler module
- `src/api/opencti/connector/post_logs.rs` - Refactored to use error handler
- `src/api/opencti/connector/post_status.rs` - Refactored to use error handler
- `src/api/opencti/connector/get_listing.rs` - Refactored to use error handler
- `src/api/opencti/manager/get_version.rs` - Refactored to use error handler
- `src/api/opencti/manager/post_ping.rs` - Refactored to use error handler
- `src/api/opencti/manager/post_register.rs` - Refactored to use error handler

## Key Features

1. **Centralized error handling** - All GraphQL responses are handled consistently
2. **Descriptive error messages** - Clear indication when backend doesn't support XTM Composer
3. **Graceful degradation** - The composer continues running even when backend operations fail

## Expected Behavior

When the OpenCTI backend doesn't support XTM Composer:
- The composer will log appropriate error messages
- The GraphQL polling will continue without crashing
- The orchestration loop will keep running
- Connectors can still be managed locally even if status/logs can't be reported to OpenCTI

## Testing

To test this fix:
1. Run the XTM composer against an OpenCTI instance that doesn't have XTM composer support
2. Observe that error messages are logged but the composer continues running
3. Verify that the orchestration loop continues to poll for changes
