### PR TITLE
[CI] Deploy latest image on dev on master push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,26 +4,25 @@ on:
   push:
     branches:
       - master
-      - ci-masterpush-deploydev
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-#      - name: Login to Docker Hub
-#        uses: docker/login-action@v3
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
-#
-#      - name: Set up Docker Buildx
-#        uses: docker/setup-buildx-action@v3
-#
-#      - name: Build and push
-#        uses: docker/build-push-action@v6
-#        with:
-#          push: true
-#          tags: filigran/${{ github.event.repository.name }}:latest
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: filigran/${{ github.event.repository.name }}:latest
 
       - name: Setup kubectl
         uses: azure/setup-kubectl@v3


### PR DESCRIPTION

As we use `latest` image tag with  `imagePullPolicy: Always`  on dev, we just need to restart the pod in order to deploy the new version. 

Token used in K8S_TOKEN_DEV secret is created following doc: https://www.notion.so/filigran/Kubectl-Infrastructure-tips-and-tricks-b15d5880befe4b9e992b94415c238866?source=copy_link#13f8fce17f2a80679af5e7c0a4390594