### PR TITLE
Add Docker network configuration support for xtm-composer

### DIFF
--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -35,6 +35,7 @@ pub struct Daemon {
     pub selector: String,
     pub portainer: Option<Portainer>,
     pub kubernetes: Option<Kubernetes>,
+    pub docker: Option<Docker>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -78,6 +79,27 @@ pub struct Portainer {
 pub struct Kubernetes {
     pub base_deployment: Option<Deployment>,
     pub base_deployment_json: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[allow(unused)]
+pub struct Docker {
+    pub network_mode: Option<String>,
+    pub extra_hosts: Option<Vec<String>>,
+    pub dns: Option<Vec<String>>,
+    pub dns_search: Option<Vec<String>>,
+    pub privileged: Option<bool>,
+    pub cap_add: Option<Vec<String>>,
+    pub cap_drop: Option<Vec<String>>,
+    pub security_opt: Option<Vec<String>>,
+    pub userns_mode: Option<String>,
+    pub pid_mode: Option<String>,
+    pub ipc_mode: Option<String>,
+    pub uts_mode: Option<String>,
+    pub runtime: Option<String>,
+    pub shm_size: Option<i64>,
+    pub sysctls: Option<std::collections::HashMap<String, String>>,
+    pub ulimits: Option<Vec<std::collections::HashMap<String, serde_json::Value>>>,
 }
 
 #[derive(Debug, Deserialize, Clone)]


### PR DESCRIPTION
This PR adds support for configuring Docker networking options in xtm-composer, allowing connectors to properly communicate with other services in Docker environments.

### Changes:
- Added `Docker` configuration struct in `src/config/settings.rs` to support various Docker host configuration options including:
  - `network_mode`: Specify Docker network mode (e.g., bridge, host, or custom network)
  - `extra_hosts`: Add custom host-to-IP mappings
  - `dns`, `dns_search`: Configure DNS settings
  - `privileged`, `cap_add`, `cap_drop`: Security and capability options
  - `security_opt`, `userns_mode`, `pid_mode`, `ipc_mode`, `uts_mode`: Namespace and security configurations
  - `runtime`, `shm_size`, `sysctls`, `ulimits`: Runtime and resource limit options

- Modified `src/orchestrator/docker/docker.rs` to apply Docker configuration options when creating containers:
  - Build `HostConfig` with options from configuration
  - Apply all configured Docker options to launched connectors
  - Properly handle ulimits conversion to Bollard's expected format

### Motivation:
Previously, connectors launched by xtm-composer couldn't resolve Docker service names (like "opencti", "rabbitmq") because they were created outside the docker-compose network. This change allows proper network configuration so connectors can communicate with other services.

### Usage Example:
```yaml
opencti:
  daemon:
    selector: docker
    docker:
      network_mode: "opencti_default"
      extra_hosts:
        - "host.docker.internal:host-gateway"
```

### Testing:
- Tested with docker-compose setup
- Verified connectors can now properly resolve and connect to OpenCTI and RabbitMQ services
- Configuration can be provided via YAML config files or environment variables

### Breaking Changes:
None - the Docker configuration is optional and backward compatible.