### PR TITLE
feat(composer): add Prometheus metrics for connector lifecycle events and global refactor (#36)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ kube = { version = "0.98.0", features = ["runtime", "derive"] }
 k8s-openapi = { version = "0.24.0", features = ["latest"] }
 base64 = "0.22.1"
 aes-gcm = "0.10.3"
+axum = "0.8.8"
+prometheus = "0.14.0"
 
 [build-dependencies]
 cynic-codegen = { version = "3" }

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -15,7 +15,9 @@ manager:
   # credentials_key_filepath: /path/to/private_key.pem
   
   # Note: If both are set, filepath takes priority with a warning
-  
+  prometheus:
+    enable: false
+    port: 14270
   logger:
     level: info
     format: json

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -82,7 +82,7 @@ impl ApiConnector {
     }
 
     pub fn container_envs(&self) -> Vec<EnvVariable> {
-        let settings = crate::settings();
+        let settings = &crate::config::settings::SETTINGS;
         let mut envs = self
             .contract_configuration
             .iter()
@@ -107,8 +107,7 @@ impl ApiConnector {
 
     /// Display environment variables with sensitive values masked (if configured)
     pub fn display_env_variables(&self) {
-        let settings = crate::settings();
-
+        let settings = &crate::config::settings::SETTINGS;
         // Check if display is enabled in configuration
         let should_display = settings
             .manager

--- a/src/api/openbas/mod.rs
+++ b/src/api/openbas/mod.rs
@@ -24,7 +24,7 @@ pub struct ApiOpenBAS {
 
 impl ApiOpenBAS {
     pub fn new() -> Self {
-        let settings = crate::settings();
+        let settings = &crate::config::settings::SETTINGS;
         let bearer = format!("{} {}", BEARER, settings.openbas.token);
         let api_uri = format!("{}/api", &settings.openbas.url);
         let daemon = settings.openbas.daemon.clone();
@@ -81,7 +81,13 @@ impl ComposerApi for ApiOpenBAS {
         todo!()
     }
 
-    async fn patch_health(&self, id: String, restart_count: u32, started_at: String, is_in_reboot_loop: bool) -> Option<cynic::Id> {
+    async fn patch_health(
+        &self,
+        id: String,
+        restart_count: u32,
+        started_at: String,
+        is_in_reboot_loop: bool,
+    ) -> Option<cynic::Id> {
         todo!()
     }
 }

--- a/src/api/opencti/manager/post_ping.rs
+++ b/src/api/opencti/manager/post_ping.rs
@@ -1,7 +1,7 @@
 use crate::api::opencti::ApiOpenCTI;
+use crate::api::opencti::error_handler::{extract_optional_field, handle_graphql_response};
 use crate::api::opencti::manager::ConnectorManager;
-use crate::api::opencti::error_handler::{handle_graphql_response, extract_optional_field};
-use crate::settings;
+
 use tracing::error;
 
 use crate::api::opencti::opencti as schema;
@@ -32,7 +32,7 @@ pub struct UpdateConnectorManagerStatusInput<'a> {
 pub async fn ping(api: &ApiOpenCTI) -> Option<String> {
     use cynic::MutationBuilder;
 
-    let settings = settings();
+    let settings = &crate::config::settings::SETTINGS;
     let vars = UpdateConnectorManagerStatusVariables {
         input: UpdateConnectorManagerStatusInput {
             id: &cynic::Id::new(&settings.manager.id),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,1 +1,2 @@
+pub mod rsa;
 pub mod settings;

--- a/src/config/rsa.rs
+++ b/src/config/rsa.rs
@@ -1,0 +1,58 @@
+use rsa::{RsaPrivateKey, pkcs8::DecodePrivateKey};
+use std::fs;
+use std::sync::LazyLock;
+use tracing::{info, warn};
+
+// Singleton RSA private key for all application
+pub static PRIVATE_KEY: LazyLock<RsaPrivateKey> =
+    LazyLock::new(|| load_and_verify_credentials_key());
+
+// Load and verify RSA private key from configuration
+fn load_and_verify_credentials_key() -> RsaPrivateKey {
+    let setting = &crate::config::settings::SETTINGS;
+
+    // Priority: file > environment variable
+    let key_content = if let Some(filepath) = &setting.manager.credentials_key_filepath {
+        // Warning if both are set
+        if setting.manager.credentials_key.is_some() {
+            warn!(
+                "Both credentials_key and credentials_key_filepath are set. Using filepath (priority)."
+            );
+        }
+
+        // Read key from file
+        match fs::read_to_string(filepath) {
+            Ok(content) => content,
+            Err(e) => panic!("Failed to read credentials key file '{}': {}", filepath, e),
+        }
+    } else if let Some(key) = &setting.manager.credentials_key {
+        // Use environment variable or config value
+        key.clone()
+    } else {
+        panic!(
+            "No credentials key provided! Set either 'manager.credentials_key' or 'manager.credentials_key_filepath' in configuration."
+        );
+    };
+
+    // Validate key format (trim to handle trailing whitespace)
+    // Check for presence of RSA PRIVATE KEY markers for PKCS#8 format
+    let trimmed_content = key_content.trim();
+    if !trimmed_content.contains("BEGIN PRIVATE KEY")
+        || !trimmed_content.contains("END PRIVATE KEY")
+    {
+        panic!(
+            "Invalid private key format. Expected PKCS#8 PEM format with 'BEGIN PRIVATE KEY' and 'END PRIVATE KEY' markers."
+        );
+    }
+
+    // Parse and validate RSA private key using PKCS#8 format
+    match RsaPrivateKey::from_pkcs8_pem(&key_content) {
+        Ok(key) => {
+            info!("Successfully loaded RSA private key (PKCS#8 format)");
+            key
+        }
+        Err(e) => {
+            panic!("Failed to decode RSA private key: {}", e);
+        }
+    }
+}

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -3,8 +3,12 @@ use k8s_openapi::api::apps::v1::Deployment;
 use k8s_openapi::api::core::v1::ResourceRequirements;
 use serde::Deserialize;
 use std::env;
+use std::sync::LazyLock;
 
 const ENV_PRODUCTION: &str = "production";
+
+// Singleton settings for all application
+pub static SETTINGS: LazyLock<Settings> = LazyLock::new(|| Settings::new().unwrap());
 
 #[derive(Debug, Deserialize, Clone)]
 #[allow(unused)]
@@ -40,6 +44,7 @@ pub struct Manager {
     pub credentials_key: Option<String>,
     pub credentials_key_filepath: Option<String>,
     pub debug: Option<Debug>,
+    pub prometheus: Option<Prometheus>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -129,6 +134,13 @@ pub struct Docker {
     pub shm_size: Option<i64>,
     pub sysctls: Option<std::collections::HashMap<String, String>>,
     pub ulimits: Option<Vec<std::collections::HashMap<String, serde_json::Value>>>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[allow(unused)]
+pub struct Prometheus {
+    pub enable: bool,
+    pub port: u16,
 }
 
 #[derive(Debug, Deserialize, Clone)]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -6,14 +6,14 @@ use crate::orchestrator::docker::DockerOrchestrator;
 use crate::orchestrator::kubernetes::KubeOrchestrator;
 use crate::orchestrator::portainer::docker::PortainerDockerOrchestrator;
 use crate::orchestrator::{Orchestrator, composer};
-use crate::settings;
+
 use crate::system::signals;
 use std::time::{Duration, Instant};
 use tokio::task::JoinHandle;
 use tokio::time::interval;
 
 async fn orchestration(api: Box<dyn ComposerApi + Send + Sync>) {
-    let settings = settings();
+    let settings = &crate::config::settings::SETTINGS;
     // Get current deployment in target orchestrator
     let daemon_configuration = api.daemon();
     let orchestrator: Box<dyn Orchestrator + Send + Sync> =
@@ -51,7 +51,7 @@ async fn orchestration(api: Box<dyn ComposerApi + Send + Sync>) {
 }
 
 pub async fn alive(api: Box<dyn ComposerApi + Send + Sync>) -> JoinHandle<()> {
-    let settings = settings();
+    let settings = &crate::config::settings::SETTINGS;
     let mut interval = interval(Duration::from_secs(settings.manager.ping_alive_schedule));
     tokio::spawn(async move {
         // Start scheduling

--- a/src/engine/openbas.rs
+++ b/src/engine/openbas.rs
@@ -1,8 +1,8 @@
-use tokio::task::JoinHandle;
-use tracing::info;
 use crate::api::ComposerApi;
 use crate::api::openbas::ApiOpenBAS;
 use crate::engine::{alive, orchestration};
+use tokio::task::JoinHandle;
+use tracing::info;
 
 pub fn openbas_orchestration() -> JoinHandle<()> {
     info!("Starting OpenBAS connectors orchestration");
@@ -19,4 +19,3 @@ pub fn openbas_alive() -> JoinHandle<()> {
         alive(api).await;
     })
 }
-

--- a/src/engine/opencti.rs
+++ b/src/engine/opencti.rs
@@ -1,8 +1,8 @@
-use tokio::task::JoinHandle;
-use tracing::info;
 use crate::api::ComposerApi;
 use crate::api::opencti::ApiOpenCTI;
 use crate::engine::{alive, orchestration};
+use tokio::task::JoinHandle;
+use tracing::info;
 
 pub fn opencti_alive() -> JoinHandle<()> {
     info!("Starting OpenCTI Composer ping alive");

--- a/src/orchestrator/kubernetes/kubernetes.rs
+++ b/src/orchestrator/kubernetes/kubernetes.rs
@@ -168,7 +168,7 @@ impl KubeOrchestrator {
         let deployment_labels: BTreeMap<String, String> = labels.into_iter().collect();
         let pod_env = self.container_envs(connector);
         let is_starting = &connector.requested_status == "starting";
-        let settings = crate::settings();
+let settings = crate::settings();
         let registry_config = settings.opencti.daemon.registry.clone();
         let resolver = Image::new(registry_config);
         let auth = resolver.get_credentials();
@@ -286,7 +286,7 @@ impl Orchestrator for KubeOrchestrator {
     }
 
     async fn list(&self) -> Vec<OrchestratorContainer> {
-        let settings = crate::settings();
+        let settings = &crate::config::settings::SETTINGS;
         let lp = &ListParams::default()
             .labels(&format!("opencti-manager={}", settings.manager.id.clone()));
         let get_deployments = self.deployments.list(lp).await.unwrap();

--- a/src/orchestrator/kubernetes/kubernetes.rs
+++ b/src/orchestrator/kubernetes/kubernetes.rs
@@ -7,7 +7,8 @@ use async_trait::async_trait;
 use k8s_openapi::DeepMerge;
 use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec};
 use k8s_openapi::api::core::v1::{
-    Container, LocalObjectReference, Secret, ContainerStatus, EnvVar, Pod, PodSpec, PodTemplateSpec, ResourceRequirements,
+    Container, ContainerStatus, EnvVar, LocalObjectReference, Pod, PodSpec, PodTemplateSpec,
+    ResourceRequirements, Secret,
 };
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta};
 use kube::api::{DeleteParams, LogParams, Patch, PatchParams};
@@ -38,7 +39,7 @@ impl KubeOrchestrator {
 
     // Validate and return image pull policy
     async fn register_secret(secrets: &Api<Secret>) {
-        let settings = crate::settings();
+        let settings = &crate::config::settings::SETTINGS;
         let registry_config = settings.opencti.daemon.registry.clone();
         let resolver = Image::new(registry_config);
         let registry_secret = resolver.get_kubernetes_registry_secret();
@@ -168,7 +169,7 @@ impl KubeOrchestrator {
         let deployment_labels: BTreeMap<String, String> = labels.into_iter().collect();
         let pod_env = self.container_envs(connector);
         let is_starting = &connector.requested_status == "starting";
-let settings = crate::settings();
+        let settings = &crate::config::settings::SETTINGS;
         let registry_config = settings.opencti.daemon.registry.clone();
         let resolver = Image::new(registry_config);
         let auth = resolver.get_credentials();

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -51,7 +51,7 @@ impl OrchestratorContainer {
 #[async_trait]
 pub trait Orchestrator {
     fn labels(&self, connector: &ApiConnector) -> HashMap<String, String> {
-        let settings = crate::settings();
+        let settings = &crate::config::settings::SETTINGS;
         let mut labels: HashMap<String, String> = HashMap::new();
         labels.insert("opencti-manager".into(), settings.manager.id.clone());
         labels.insert("opencti-connector-id".into(), connector.id.clone());

--- a/src/orchestrator/portainer/docker/portainer.rs
+++ b/src/orchestrator/portainer/docker/portainer.rs
@@ -179,7 +179,7 @@ impl Orchestrator for PortainerDockerOrchestrator {
     }
 
     async fn deploy(&self, connector: &ApiConnector) -> Option<OrchestratorContainer> {
-        let settings = crate::settings();
+        let settings = &crate::config::settings::SETTINGS;
         let registry_config = settings.opencti.daemon.registry.clone();
         let resolver = Image::new(registry_config);
         let auth = resolver.get_credentials();

--- a/src/orchestrator/portainer/docker/portainer.rs
+++ b/src/orchestrator/portainer/docker/portainer.rs
@@ -92,7 +92,7 @@ impl Orchestrator for PortainerDockerOrchestrator {
     }
 
     async fn list(&self) -> Vec<OrchestratorContainer> {
-        let settings = crate::settings();
+        let settings = &crate::config::settings::SETTINGS;
         let mut label_filters = Vec::new();
         label_filters.push(format!("opencti-manager={}", settings.manager.id.clone()));
         let filter: HashMap<String, Vec<String>> = HashMap::from([("label".into(), label_filters)]);

--- a/src/prometheus/mod.rs
+++ b/src/prometheus/mod.rs
@@ -1,0 +1,87 @@
+use axum::{Router, routing::get};
+use prometheus::{Encoder, IntCounter, IntGauge, Registry, TextEncoder};
+use std::net::SocketAddr;
+use std::sync::LazyLock;
+use tracing::info;
+
+// Registry initialization
+pub static REGISTRY: LazyLock<Registry> = LazyLock::new(|| Registry::new());
+
+// region Metrics initialization
+pub static MANAGED_CONNECTORS: LazyLock<IntGauge> = LazyLock::new(|| {
+    let gauge = IntGauge::new(
+        "xtm_managed_connectors",
+        "Number of protected connectors managed by the composer",
+    )
+    .expect("metric can be created");
+    REGISTRY
+        .register(Box::new(gauge.clone()))
+        .expect("collector can be registered");
+    gauge
+});
+
+pub static CONNECTOR_INITIALIZED: LazyLock<IntCounter> = LazyLock::new(|| {
+    let counter = IntCounter::new(
+        "xtm_connectors_initialized_total",
+        "Number of connectors initialized",
+    )
+    .expect("metric can be created");
+    REGISTRY
+        .register(Box::new(counter.clone()))
+        .expect("collector can be registered");
+    counter
+});
+
+pub static CONNECTOR_STARTED: LazyLock<IntCounter> = LazyLock::new(|| {
+    let counter = IntCounter::new(
+        "xtm_connectors_started_total",
+        "Number of connectors started",
+    )
+    .expect("metric can be created");
+    REGISTRY
+        .register(Box::new(counter.clone()))
+        .expect("collector can be registered");
+    counter
+});
+
+pub static CONNECTOR_STOPPED: LazyLock<IntCounter> = LazyLock::new(|| {
+    let counter = IntCounter::new(
+        "xtm_connectors_stopped_total",
+        "Number of connectors stopped",
+    )
+    .expect("metric can be created");
+    REGISTRY
+        .register(Box::new(counter.clone()))
+        .expect("collector can be registered");
+    counter
+});
+
+pub static CONNECTOR_UPDATED: LazyLock<IntCounter> = LazyLock::new(|| {
+    let counter = IntCounter::new(
+        "xtm_connectors_updated_total",
+        "Number of connectors updated",
+    )
+    .expect("metric can be created");
+    REGISTRY
+        .register(Box::new(counter.clone()))
+        .expect("collector can be registered");
+    counter
+});
+// endregion
+
+// Functions
+async fn metrics_handler() -> String {
+    let mut buffer = Vec::new();
+    let encoder = TextEncoder::new();
+    let metric_families = REGISTRY.gather();
+    encoder.encode(&metric_families, &mut buffer).unwrap();
+    String::from_utf8(buffer).unwrap()
+}
+
+pub async fn start_metrics_server(port: u16) {
+    let app = Router::new().route("/metrics", get(metrics_handler));
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    info!("Prometheus server listening on {}/metrics", addr);
+    let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
+    axum::serve(listener, app).await.unwrap();
+}


### PR DESCRIPTION
See #36
+ quallity code refactoring

Implemented configuration.

```
manager:
  ....
  prometheus:
    enable: false
    port: 14270
```

Metrics implemented

```
        "xtm_managed_connectors",
        "Number of protected connectors managed by the composer",
```

```
        "xtm_connectors_initialized_total",
        "Number of connectors initialized",
```

```
        "xtm_connectors_started_total",
        "Number of connectors started",
```

```
        "xtm_connectors_stopped_total",
        "Number of connectors stopped",
```

```
        "xtm_connectors_updated_total",
        "Number of connectors updated",
```