### PR TITLE
default to the docker daemon in selector

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -37,7 +37,7 @@ opencti:
     #   username: "your-username"
     #   password: "your-password"
     #   email: "your-email@example.com"
-    selector: docker
+    selector: kubernetes
     kubernetes:
       # Image pull policy for K8s containers created by xtmcomposer
       # Valid values: Always, IfNotPresent, Never  
@@ -67,7 +67,7 @@ openaev:
     #   username: "your-username"
     #   password: "your-password"
     #   email: "your-email@example.com"
-    selector: docker
+    selector: kubernetes
     kubernetes:
       # Image pull policy for K8s containers created by xtmcomposer
       # Valid values: Always, IfNotPresent, Never  


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the xtm-composer project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes
* Defaulting to the docker daemon in the selector

Unify the defaults between opencti and openaev; favour the plain docker daemon as the more common deployment scenario
