### PR TITLE
fix: clean up orphaned collectors after connector rename

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtm-composer"
-version = "3.260506.0"
+version = "3.260520.0"
 edition = "2024"
 
 [dependencies]

--- a/src/orchestrator/composer.rs
+++ b/src/orchestrator/composer.rs
@@ -173,8 +173,20 @@ pub async fn orchestrate(
                 continue;
             }
             let connector_id = container.extract_opencti_id();
-            if !connectors_by_id.contains_key(&connector_id) {
-                orchestrator.remove(&container).await;
+            match connectors_by_id.get(&connector_id) {
+                None => {
+                    // Connector no longer exists — remove the orphaned container
+                    orchestrator.remove(&container).await;
+                }
+                Some(connector) => {
+                    // Connector still exists but the deployment name may be stale
+                    // (e.g. after a platform rename). Remove the old deployment so
+                    // the next orchestration cycle deploys with the correct name.
+                    let expected_name = connector.container_name();
+                    if container.name != expected_name {
+                        orchestrator.remove(&container).await;
+                    }
+                }
             }
         }
     }
@@ -211,7 +223,7 @@ mod tests {
 
         OrchestratorContainer {
             id: format!("container-{id}"),
-            name: format!("connector-{id}"),
+            name: format!("connector-{}", id.to_lowercase()),
             state: "exited".to_string(),
             labels,
             envs,
@@ -230,7 +242,7 @@ mod tests {
 
         OrchestratorContainer {
             id: format!("container-{id}"),
-            name: format!("connector-{id}"),
+            name: format!("connector-{}", id.to_lowercase()),
             state: "exited".to_string(),
             labels,
             envs,
@@ -468,5 +480,66 @@ mod tests {
             .expect("mutex should not be poisoned")
             .clone();
         assert!(removed.is_empty(), "active legacy container should not be removed: {removed:?}");
+    }
+
+    #[tokio::test]
+    async fn cleanup_removes_stale_named_container_after_connector_rename() {
+        // Simulates OpenAEV 2.4.0 scenario: connector ID stays the same but the
+        // name changes (e.g. "connector-A" → "connector-a-0f2a85c1").
+        // The old deployment should be removed as orphaned.
+        let mut stale_container = managed_container("A", "opencti");
+        stale_container.name = "connector-a-old-name".to_string();
+
+        let all_containers = vec![
+            stale_container,
+            managed_container("B", "opencti"),
+        ];
+
+        let removed_ids = Arc::new(Mutex::new(Vec::new()));
+        let orchestrator: Box<dyn Orchestrator + Send + Sync> =
+            Box::new(FakeOrchestrator::new(all_containers, Arc::clone(&removed_ids)));
+        let api: Box<dyn ComposerApi + Send + Sync> =
+            Box::new(FakeApi::new(vec![connector("A"), connector("B")]));
+
+        let mut tick = Instant::now();
+        let mut health_tick = Instant::now();
+
+        orchestrate(&mut tick, &mut health_tick, &orchestrator, &api).await;
+
+        let removed = removed_ids
+            .lock()
+            .expect("mutex should not be poisoned")
+            .clone();
+        assert_eq!(
+            removed,
+            vec!["A".to_string()],
+            "stale-named container should be removed"
+        );
+    }
+
+    #[tokio::test]
+    async fn cleanup_keeps_correctly_named_container() {
+        // When the container name matches the expected container_name(), it should be kept.
+        let all_containers = vec![
+            managed_container("A", "opencti"),
+            managed_container("B", "opencti"),
+        ];
+
+        let removed_ids = Arc::new(Mutex::new(Vec::new()));
+        let orchestrator: Box<dyn Orchestrator + Send + Sync> =
+            Box::new(FakeOrchestrator::new(all_containers, Arc::clone(&removed_ids)));
+        let api: Box<dyn ComposerApi + Send + Sync> =
+            Box::new(FakeApi::new(vec![connector("A"), connector("B")]));
+
+        let mut tick = Instant::now();
+        let mut health_tick = Instant::now();
+
+        orchestrate(&mut tick, &mut health_tick, &orchestrator, &api).await;
+
+        let removed = removed_ids
+            .lock()
+            .expect("mutex should not be poisoned")
+            .clone();
+        assert!(removed.is_empty(), "correctly named containers should not be removed: {removed:?}");
     }
 }

--- a/src/orchestrator/composer.rs
+++ b/src/orchestrator/composer.rs
@@ -180,8 +180,9 @@ pub async fn orchestrate(
                 }
                 Some(connector) => {
                     // Connector still exists but the deployment name may be stale
-                    // (e.g. after a platform rename). Remove the old deployment so
-                    // the next orchestration cycle deploys with the correct name.
+                    // after a connector instance name change while the connector ID
+                    // remains the same. Remove the old deployment so the next
+                    // orchestration cycle deploys with the correct name.
                     let expected_name = connector.container_name();
                     if container.name != expected_name {
                         orchestrator.remove(&container).await;

--- a/src/orchestrator/kubernetes/kubernetes.rs
+++ b/src/orchestrator/kubernetes/kubernetes.rs
@@ -306,18 +306,19 @@ impl Orchestrator for KubeOrchestrator {
     }
 
     async fn remove(&self, container: &OrchestratorContainer) -> () {
-        let lp = &ListParams::default().labels(&format!(
-            "opencti-connector-id={}",
-            container.extract_opencti_id()
-        ));
         let dp = &DeleteParams::default();
-        let delete_response = self.deployments.delete_collection(dp, lp).await;
+        let delete_response = self.deployments.delete(&container.name, dp).await;
         match delete_response {
             Ok(_) => info!(
+                name = container.name,
                 id = container.extract_opencti_id(),
                 "Deployment successfully deleted"
             ),
-            Err(err) => error!(error = err.to_string(), "Fail removing the deployments"),
+            Err(err) => error!(
+                name = container.name,
+                error = err.to_string(),
+                "Fail removing the deployment"
+            ),
         }
     }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request to the xtm-composer project! We as a community
driven project depend on support and contributions like this!

Thus already a BIG THANK YOU upfront to you for choosing to help with your PR.
-->

### Proposed changes

 **Cleanup logic** (`composer.rs`): The existing cleanup loop already removes containers whose `connector-id` no longer matches any active connector. This adds a check in the same loop: if the `connector-id` *is* active but the container name doesn't match the expected `container_name()`, the container is also removed as stale.
 
 **Kubernetes `remove()`** (`kubernetes.rs`): Changed from `delete_collection` by label to `delete` by deployment name. This is mandatory because at cleanup time, both old and new deployments share the same `connector-id` label: a bulk delete would destroy both. Other orchestrators (Docker, Swarm, Portainer) already delete by name/ID, so no change needed there.

### Note

The proper fix is making `get()` label-based across all backends (eliminating the name/label asymmetry). Shipping this minimal fix first because:

 - Urgency: this is blocking the OpenAEV 2.4 release
 - Scope: 2 files vs 5 files touching all 4 orchestrator backends
 - Risk: cleanup logic is unit-testable; the refactor needs integration testing on real infra

Trade-off: brief double-container window (~1 cycle) before cleanup catches stale deployments.

### Related issues
* https://github.com/FiligranHQ/xtm-composer/issues/102
