### PR TITLE
fix: make Kubernetes Deployment selector immutable-safe (#104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3565,7 +3565,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xtm-composer"
-version = "3.260520.0"
+version = "3.260527.0"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3565,7 +3565,7 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xtm-composer"
-version = "3.260527.0"
+version = "3.260528.0"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtm-composer"
-version = "3.260520.0"
+version = "3.260527.0"
 edition = "2024"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtm-composer"
-version = "3.260527.0"
+version = "3.260528.0"
 edition = "2024"
 
 [dependencies]

--- a/src/orchestrator/kubernetes/kubernetes.rs
+++ b/src/orchestrator/kubernetes/kubernetes.rs
@@ -234,6 +234,16 @@ impl KubeOrchestrator {
         base_deployment
     }
 
+    pub fn build_refresh_patch(deployment: &Deployment) -> serde_json::Value {
+        // spec.selector is immutable after creation — strip it from the merge
+        // patch so Kubernetes leaves the existing selector untouched.
+        let mut patch_value = serde_json::to_value(deployment).unwrap();
+        if let Some(spec) = patch_value.pointer_mut("/spec") {
+            spec.as_object_mut().unwrap().remove("selector");
+        }
+        patch_value
+    }
+
     // Enrich container with pod information
     fn enrich_container_from_pod(&self, container: &mut OrchestratorContainer, pod: Pod) {
         let container_status = pod
@@ -326,12 +336,7 @@ impl Orchestrator for KubeOrchestrator {
     async fn refresh(&self, connector: &ApiConnector) -> Option<OrchestratorContainer> {
         let labels = self.labels(connector);
         let deployment_patch = self.build_configuration(connector, labels);
-        // spec.selector is immutable after creation — strip it from the merge
-        // patch so Kubernetes leaves the existing selector untouched.
-        let mut patch_value = serde_json::to_value(&deployment_patch).unwrap();
-        if let Some(spec) = patch_value.pointer_mut("/spec") {
-            spec.as_object_mut().unwrap().remove("selector");
-        }
+        let patch_value = Self::build_refresh_patch(&deployment_patch);
         let patch = Patch::Merge(&patch_value);
         let name = connector.container_name();
         let deployment_result = self

--- a/src/orchestrator/kubernetes/kubernetes.rs
+++ b/src/orchestrator/kubernetes/kubernetes.rs
@@ -173,6 +173,10 @@ impl KubeOrchestrator {
         let resolver = Image::new(registry_config);
         let auth = resolver.get_credentials();
         let image = resolver.build_name(connector.image.clone());
+        let selector = LabelSelector {
+            match_labels: Some(deployment_labels.clone()),
+            ..Default::default()
+        };
         let target_deployment = Deployment {
             metadata: ObjectMeta {
                 name: Some(connector.container_name()),
@@ -186,10 +190,7 @@ impl KubeOrchestrator {
             },
             spec: Some(DeploymentSpec {
                 replicas: Some(if is_starting { 1 } else { 0 }),
-                selector: LabelSelector {
-                    match_labels: Some(deployment_labels.clone()),
-                    ..Default::default()
-                },
+                selector,
                 template: PodTemplateSpec {
                     metadata: Some(ObjectMeta {
                         labels: Some(deployment_labels.clone()),
@@ -325,7 +326,13 @@ impl Orchestrator for KubeOrchestrator {
     async fn refresh(&self, connector: &ApiConnector) -> Option<OrchestratorContainer> {
         let labels = self.labels(connector);
         let deployment_patch = self.build_configuration(connector, labels);
-        let patch = Patch::Merge(&deployment_patch);
+        // spec.selector is immutable after creation — strip it from the merge
+        // patch so Kubernetes leaves the existing selector untouched.
+        let mut patch_value = serde_json::to_value(&deployment_patch).unwrap();
+        if let Some(spec) = patch_value.pointer_mut("/spec") {
+            spec.as_object_mut().unwrap().remove("selector");
+        }
+        let patch = Patch::Merge(&patch_value);
         let name = connector.container_name();
         let deployment_result = self
             .deployments

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -89,6 +89,7 @@ pub trait Orchestrator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::orchestrator::kubernetes::KubeOrchestrator;
 
     #[test]
     fn labels_include_platform_discriminator() {
@@ -192,6 +193,42 @@ mod tests {
             match_labels.get("opencti-platform").and_then(|v| v.as_str()),
             Some("opencti"),
             "selector must contain the platform label"
+        );
+    }
+
+    #[test]
+    fn build_refresh_patch_strips_selector() {
+        // This test calls KubeOrchestrator::build_refresh_patch directly.
+        use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec};
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
+        use std::collections::BTreeMap;
+
+        let deployment = Deployment {
+            spec: Some(DeploymentSpec {
+                replicas: Some(2),
+                selector: LabelSelector {
+                    match_labels: Some(BTreeMap::from([(
+                        "opencti-connector-id".to_string(),
+                        "abc-123".to_string(),
+                    )])),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let patch = KubeOrchestrator::build_refresh_patch(&deployment);
+
+        let spec = patch.get("spec").expect("spec must be present");
+        assert!(
+            spec.get("selector").is_none(),
+            "build_refresh_patch() must strip spec.selector — got: {spec}"
+        );
+        assert_eq!(
+            spec.get("replicas").and_then(|v: &serde_json::Value| v.as_i64()),
+            Some(2),
+            "other spec fields must survive"
         );
     }
 }

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -109,4 +109,89 @@ mod tests {
         assert_eq!(labels.get("opencti-platform"), Some(&connector.platform));
         assert_eq!(labels.get("opencti-manager"), Some(&"test-manager".to_string()));
     }
+
+    #[test]
+    fn refresh_patch_strips_selector_from_deployment_spec() {
+        // refresh() strips spec.selector from the merge patch so that
+        // the immutable field is never sent to Kubernetes.
+        use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec};
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
+        use std::collections::BTreeMap;
+
+        let deployment = Deployment {
+            spec: Some(DeploymentSpec {
+                replicas: Some(1),
+                selector: LabelSelector {
+                    match_labels: Some(BTreeMap::from([(
+                        "opencti-connector-id".to_string(),
+                        "abc-123".to_string(),
+                    )])),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let mut patch_value = serde_json::to_value(&deployment).unwrap();
+        if let Some(spec) = patch_value.pointer_mut("/spec") {
+            spec.as_object_mut().unwrap().remove("selector");
+        }
+
+        let spec = patch_value.get("spec").expect("spec must exist");
+        assert!(
+            spec.get("selector").is_none(),
+            "selector should be stripped from the patch: {spec}"
+        );
+        assert_eq!(
+            spec.get("replicas").and_then(|v| v.as_i64()),
+            Some(1),
+            "other spec fields must survive"
+        );
+    }
+
+    #[test]
+    fn deploy_payload_includes_all_labels_in_selector() {
+        // deploy() sends the full Deployment including the selector with
+        // all labels so Kubernetes can match pods precisely.
+        use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec};
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
+        use std::collections::BTreeMap;
+
+        let labels: BTreeMap<String, String> = BTreeMap::from([
+            ("opencti-manager".to_string(), "test-manager".to_string()),
+            ("opencti-connector-id".to_string(), "connector-42".to_string()),
+            ("opencti-platform".to_string(), "opencti".to_string()),
+        ]);
+        let deployment = Deployment {
+            spec: Some(DeploymentSpec {
+                selector: LabelSelector {
+                    match_labels: Some(labels.clone()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_value(&deployment).unwrap();
+        let match_labels = json
+            .pointer("/spec/selector/matchLabels")
+            .expect("matchLabels must be present");
+        assert_eq!(
+            match_labels.get("opencti-connector-id").and_then(|v| v.as_str()),
+            Some("connector-42"),
+            "selector must contain the connector-id label"
+        );
+        assert_eq!(
+            match_labels.get("opencti-manager").and_then(|v| v.as_str()),
+            Some("test-manager"),
+            "selector must contain the manager label"
+        );
+        assert_eq!(
+            match_labels.get("opencti-platform").and_then(|v| v.as_str()),
+            Some("opencti"),
+            "selector must contain the platform label"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #104

  ## Problem

  `spec.selector` is immutable in Kubernetes Deployments. In `3.260506.0` (commit `bf3a178`), `opencti-platform` was added to the deployment labels. Since `build_configuration()` used **all labels** as `spec.selector.match_labels`, any
  deployment created before that version rejects refresh patches because the selector changed.

  **Impact:** connectors deployed before `3.260506.0` cannot be refreshed, reconfigured, or upgraded. They stay stuck on their old image/config.

  ## Fix

  - **`build_configuration()` keeps using all labels as the selector** (`manager`, `connector-id`, `platform`) preserving multi-instance/multi-platform isolation
  - **`refresh()` strips `spec.selector`** from the serialized JSON before sending the merge patch, so Kubernetes leaves the existing (immutable) selector untouched
  - **`deploy()` sends the full payload** including the selector, so new deployments are created with the correct match labels
  - **Added tests** verifying selector stripping in refresh patches and all-labels presence in deploy payloads

  ## Result

  Seamless upgrade. Existing deployments keep their current selector untouched on refresh. New deployments get the full 3-label selector for proper isolation.