### PR TITLE
chore(renovate): emit Conventional Commits titles (#117)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
+    ":semanticCommits",
     "config:recommended",
     "docker:enableMajor"
   ],
@@ -8,7 +9,6 @@
     "dependencies",
     "filigran team"
   ],
-  "commitMessagePrefix": "[deps]",
   "minimumReleaseAge": "3 days",
   "prHourlyLimit": 2,
   "prConcurrentLimit": 100,


### PR DESCRIPTION
## Summary

Renovate now emits Conventional Commits titles (`chore(deps): ...`) instead of the old `[deps]` bracket prefix.

Closes #117