### PR TITLE
chore: align issue templates across repositories (#119)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,8 +2,9 @@
 name: Bug report
 about: Create a bug report to help us improve XTM Composer
 title: 'fix: '
-labels: bug, needs triage
+labels: needs triage, bug
 assignees: ''
+type: bug
 
 ---
 
@@ -13,48 +14,25 @@ assignees: ''
 
 ## Environment
 
-1. OS (where XTM Composer runs): { e.g. Mac OS 10, Windows 10, Ubuntu 22.04, etc. }
-2. XTM Composer version: { e.g. XTM Composer 0.1.0 }
-3. Rust version: { e.g. 1.70.0 }
-4. Orchestrator: { e.g. Docker, Kubernetes, Portainer }
-5. OpenCTI version: { e.g. OpenCTI 6.0.0 }
-6. Other environment details:
+1. OS: { e.g. macOS 14, Windows 11, Ubuntu 22.04, etc. }
+2. Version: { e.g. 1.2.3 }
+3. Other environment details:
 
-## Reproducible Steps
+## Reproducible steps
 
 Steps to create the smallest reproducible scenario:
-1. { e.g. Configure XTM Composer with ... }
-2. { e.g. Run command ... }
-3. { e.g. Error occurs ... }
+1. { e.g. Run ... }
+2. { e.g. Click ... }
+3. { e.g. Error ... }
 
-## Expected Output
+## Expected output
 
 <!-- Please describe what you expected to happen. -->
 
-## Actual Output
+## Actual output
 
 <!-- Please describe what actually happened. -->
-
-## Configuration
-
-<!-- Please provide your configuration file (with sensitive data removed) -->
-
-```yaml
-# config/default.yaml or relevant configuration
-```
-
-## Logs
-
-<!-- Please provide relevant log output -->
-
-```
-# Log output here
-```
 
 ## Additional information
 
 <!-- Any additional information, including logs or screenshots if you have any. -->
-
-## Screenshots (optional)
-
-<!-- If applicable, add screenshots to help explain your problem. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/FiligranHQ/xtm-composer/security/policy
+    about: Please review our security policy and report vulnerabilities privately and responsibly.
+  - name: Filigran community Slack
+    url: https://community.filigran.io
+    about: Ask questions and chat with the Filigran community.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature request
-about: Ask for a new feature to be implemented in XTM Composer
+about: Suggest a new feature or capability for XTM Composer
 title: 'feat: '
-labels: enhancement, needs triage
+labels: needs triage, feature
 assignees: ''
 type: feature
 
@@ -10,35 +10,20 @@ type: feature
 
 ## Use case
 
-<!-- Please describe the use case for which you need a solution -->
+<!-- Please describe the use case for which you need a solution. -->
 
-## Current Workaround
+## Current workaround
 
-<!-- Please describe how you currently solve or work around this problem, given XTM Composer's limitation. -->
+<!-- Please describe how you currently solve or work around this problem. -->
 
-## Proposed Solution
+## Proposed solution
 
-<!-- Please describe the solution you would like XTM Composer to provide, to solve the problem above. -->
+<!-- Please describe the solution you would like to be provided. -->
 
-## Implementation Details (Optional)
+## Additional information
 
-<!-- If you have specific implementation ideas, please share them here -->
-
-### Affected Components
-<!-- Check all that apply -->
-- [ ] Configuration management
-- [ ] OpenCTI API integration
-- [ ] Docker orchestration
-- [ ] Kubernetes orchestration
-- [ ] Portainer integration
-- [ ] Connector management
-- [ ] Documentation
-- [ ] Other (please specify)
-
-## Additional Information
-
-<!-- Any additional information, including logs, configuration examples, or screenshots if you have any. -->
+<!-- Any additional information, including logs or screenshots if you have any. -->
 
 ## If the feature request is approved, would you be willing to submit a PR?
 
-Yes / No (Help can be provided if you need assistance submitting a PR)
+Yes / No (help can be provided if you need assistance submitting a PR)

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,17 +1,17 @@
 ---
 name: Question
-about: Ask a question concerning XTM Composer
+about: Ask a question about XTM Composer
 title: ''
-labels: question, needs triage
+labels: needs triage, question
 assignees: ''
 
 ---
 
 ## Prerequisites
 
-- [ ] I read the [Installation](https://github.com/OpenCTI-Platform/xtm-composer/blob/main/docs/installation.md) and [Configuration](https://github.com/OpenCTI-Platform/xtm-composer/blob/main/docs/configuration.md) documentation and didn't find anything relevant to my problem.
-- [ ] I went through old GitHub issues and couldn't find anything relevant
-- [ ] I googled the issue and didn't find anything relevant
+- [ ] I read the documentation and didn't find anything relevant to my problem.
+- [ ] I went through old GitHub issues and couldn't find anything relevant.
+- [ ] I searched the web and didn't find anything relevant.
 
 ## Description
 
@@ -19,49 +19,10 @@ assignees: ''
 
 ## Environment
 
-1. OS (where XTM Composer runs): { e.g. Mac OS 10, Windows 10, Ubuntu 22.04, etc. }
-2. XTM Composer version: { e.g. XTM Composer 0.1.0 }
-3. Rust version: { e.g. 1.70.0 }
-4. Orchestrator: { e.g. Docker, Kubernetes, Portainer }
-5. OpenCTI version: { e.g. OpenCTI 6.0.0 }
-6. Other environment details:
-
-## Context
-
-<!-- If your question relates to a specific use case or scenario, please describe it here -->
-
-### Related Components
-<!-- Check all that apply to help us understand the context -->
-- [ ] Configuration management
-- [ ] OpenCTI API integration
-- [ ] Docker orchestration
-- [ ] Kubernetes orchestration
-- [ ] Portainer integration
-- [ ] Connector management
-- [ ] Documentation
-- [ ] Installation/Setup
-- [ ] Other (please specify)
-
-## Reproducible Steps (if applicable)
-
-<!-- If your question relates to a specific scenario, please provide steps -->
-Steps to reproduce the scenario:
-1. { e.g. Configure XTM Composer with ... }
-2. { e.g. Run command ... }
-3. { e.g. Observe behavior ... }
-
-## Configuration (if relevant)
-
-<!-- If your question relates to configuration, please provide your configuration file (with sensitive data removed) -->
-
-```yaml
-# config/default.yaml or relevant configuration
-```
-
-## What I've Tried
-
-<!-- Please describe any attempts you've made to solve or understand the issue -->
+1. OS: { e.g. macOS 14, Windows 11, Ubuntu 22.04, etc. }
+2. Version: { e.g. 1.2.3 }
+3. Other environment details:
 
 ## Additional information
 
-<!-- Any additional information, including logs, error messages, or screenshots if you have any. -->
+<!-- Any additional information, including logs or screenshots if you have any. -->


### PR DESCRIPTION
## Summary

Aligns the issue templates across all Filigran repositories (identical bug / feature / question + a security vulnerability link), adds a documentation request template where the repo ships docs, and keeps client-python templates where applicable.

Closes #119