### PR TITLE
build: harden Docker image security by pulling latest base images on build (#106)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ env.REGISTRY_IMAGE }}
+          pull: true
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,7 @@ jobs:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ env.REGISTRY_IMAGE }}
+          pull: true
           outputs: type=image,push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest


### PR DESCRIPTION
Add `pull: true` to `docker/build-push-action` in both `main.yml` and `release.yml` CI workflows to ensure the latest base images are always pulled before building, preventing builds on cached, outdated images with potential security vulnerabilities.

Closes #106