### PR TITLE
ci: add check for PR linked issue (#76)

### DIFF
--- a/.github/workflows/check-pr-issue.yml
+++ b/.github/workflows/check-pr-issue.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   check-pr-issue:

--- a/.github/workflows/check-pr-issue.yml
+++ b/.github/workflows/check-pr-issue.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   check-pr-issue:

--- a/.github/workflows/check-pr-issue.yml
+++ b/.github/workflows/check-pr-issue.yml
@@ -1,0 +1,31 @@
+name: Check PR Linked Issue
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, ready_for_review, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check-pr-issue:
+    name: Check Pull Request is linked to an issue
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for linked issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          LINKED_ISSUES=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json closingIssuesReferences --jq '.closingIssuesReferences | length')
+
+          if [ "$LINKED_ISSUES" -eq 0 ]; then
+            echo "::error::No linked issues found. Please link at least one issue to this Pull Request."
+            echo "You can link an issue by using keywords like 'Fixes #123', 'Closes #123', or 'Resolves #123' in the PR description."
+            exit 1
+          else
+            echo "✓ Found $LINKED_ISSUES linked issue(s)"
+          fi


### PR DESCRIPTION
Closes #76

## Summary

Adds a GitHub Actions workflow (`check-pr-issue.yml`) that verifies every pull request has at least one linked issue. This ensures release notes can be generated properly since they rely on linked issues.

## Details

- Triggers on PR open, edit, reopen, ready_for_review, and synchronize events
- Skips PRs labeled `dependencies` (e.g. Renovate/Snyk)
- Uses `gh pr view` to check for closing issues references
- Fails with a clear error message if no issue is linked