### PR TITLE
ci: add workflow to auto-label new issues with "needs triage" (#85)

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -1,0 +1,20 @@
+name: Auto-label new issues
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-needs-triage:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['needs triage']
+            });


### PR DESCRIPTION
Adds a GitHub Actions workflow that triggers on `issues: opened` and applies the `needs triage` label to every newly created issue — covering API-created issues, blank issues, and any that bypass templates.

Closes #85