### PR TITLE
fix(deps): upgrade bollard to 0.21.0 (#142)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,9 +238,9 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.19.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a52479c9237eb04047ddb94788c41ca0d26eaff8b697ecfbb4c32f7fdc3b1b"
+checksum = "c9d0a013e3d3ee4edd61e779adf117944c08902d375f18630a0c5b8f95659734"
 dependencies = [
  "base64",
  "bollard-stubs",
@@ -259,7 +259,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_repr",
  "serde_urlencoded",
  "thiserror 2.0.18",
  "tokio",
@@ -271,23 +270,13 @@ dependencies = [
 
 [[package]]
 name = "bollard-stubs"
-version = "1.49.1-rc.28.4.0"
+version = "1.53.1-rc.29.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5731fe885755e92beff1950774068e0cae67ea6ec7587381536fca84f1779623"
+checksum = "ce412eb6f7096743011dc3cb5c674caeb24ced61d8c498fe07cf7998a4fea889"
 dependencies = [
  "serde",
  "serde_json",
  "serde_repr",
- "serde_with",
-]
-
-[[package]]
-name = "bs58"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
-dependencies = [
- "tinyvec",
 ]
 
 [[package]]
@@ -335,7 +324,6 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
- "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -547,7 +535,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4dfae2e0e25c72720197bde791ef9b840562ed6418eab6d8505f1d8fed27e86"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "lalrpop-util",
  "logos",
 ]
@@ -681,9 +669,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "serde_core",
-]
 
 [[package]]
 name = "derive_more"
@@ -1067,18 +1052,12 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1422,25 +1401,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
-name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1677,7 +1643,7 @@ dependencies = [
  "jiff",
  "json-patch",
  "k8s-openapi",
- "schemars 1.2.1",
+ "schemars",
  "serde",
  "serde-value",
  "serde_json",
@@ -2514,9 +2480,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -2632,18 +2598,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "schemars"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -2840,25 +2794,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serde_with"
-version = "3.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
-dependencies = [
- "base64",
- "bs58",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.14.0",
- "schemars 0.9.0",
- "schemars 1.2.1",
- "serde_core",
- "serde_json",
- "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 slug = { version = "0.1" }
 rsa = { version = "0.9.9" }
-bollard = { version = "0.19.4" }
+bollard = { version = "0.21.0" }
 chrono = { version = "0.4.42" }
 futures = { version = "0.3.31" }
 rolling-file = { version = " 0.2.0" }

--- a/src/orchestrator/docker/docker.rs
+++ b/src/orchestrator/docker/docker.rs
@@ -186,7 +186,7 @@ impl Orchestrator for DockerOrchestrator {
                     "{} {:?} {:?} pulling...",
                     image,
                     info.status.as_deref(),
-                    info.progress.as_deref()
+                    info.progress_detail.as_ref()
                 );
                 future::ok(())
             })

--- a/src/orchestrator/swarm/swarm.rs
+++ b/src/orchestrator/swarm/swarm.rs
@@ -7,7 +7,7 @@ use crate::orchestrator::{Orchestrator, OrchestratorContainer};
 use async_trait::async_trait;
 use bollard::auth::DockerCredentials;
 use bollard::models::{
-    Limit, Mount, MountTypeEnum, NetworkAttachmentConfig, ResourceObject, ResourcesUlimits,
+    Limit, Mount, MountType, NetworkAttachmentConfig, ResourceObject, ResourcesUlimits,
     ServiceSpec,
     ServiceSpecMode, ServiceSpecModeReplicated, TaskSpec, TaskSpecContainerSpec,
     TaskSpecContainerSpecDnsConfig, TaskSpecPlacement, TaskSpecPlacementPreferences,
@@ -276,7 +276,7 @@ impl Orchestrator for SwarmOrchestrator {
                     "{} {:?} {:?} pulling...",
                     image,
                     info.status.as_deref(),
-                    info.progress.as_deref()
+                    info.progress_detail.as_ref()
                 );
                 future::ok(())
             })
@@ -360,7 +360,7 @@ impl Orchestrator for SwarmOrchestrator {
                 if let Some(proxy_ca_host_path) = ensure_proxy_ca_file(connector) {
                     let mut mounts = container_spec.mounts.unwrap_or_default();
                     mounts.push(Mount {
-                        typ: Some(MountTypeEnum::BIND),
+                        typ: Some(MountType::BIND),
                         source: Some(proxy_ca_host_path),
                         target: Some(PROXY_CA_CERT_MOUNT_PATH.to_string()),
                         read_only: Some(true),
@@ -401,6 +401,8 @@ impl Orchestrator for SwarmOrchestrator {
                     TaskSpecResources {
                         limits,
                         reservations,
+                        memory_swappiness: None,
+                        swap_bytes: None,
                     }
                 });
 


### PR DESCRIPTION
## Summary

Upgrades bollard from 0.19.4 to 0.21.0, adapting code for breaking changes in the 0.20 → 0.21 release cycle.

### Changes
- **`MountTypeEnum` → `MountType`**: Type was renamed in bollard 0.21
- **`CreateImageInfo.progress` removed**: Replaced with `progress_detail` in logging statements
- **`TaskSpecResources` new required fields**: Added `memory_swappiness: None, swap_bytes: None`

### Context
PR #58 (Renovate) updated the bollard version but CI failed due to these breaking changes. This PR supersedes #58 by including both the version bump and the required code adaptations.

Closes #142