### PR TITLE
fix: install rustls CryptoProvider at startup (#140)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2514,9 +2514,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -3891,6 +3891,7 @@ dependencies = [
  "reqwest",
  "rolling-file",
  "rsa",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ k8s-openapi = { version = "0.28.0", features = ["v1_32"] }
 base64 = "0.22.1"
 aes-gcm = "0.10.3"
 sha2 = "0.10.8"
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs"] }
 
 [build-dependencies]
 cynic-codegen = { version = "3" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use tracing_subscriber::fmt::writer::MakeWriterExt;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::{Registry, layer::SubscriberExt};
 use rsa::{RsaPrivateKey, pkcs8::DecodePrivateKey};
+use rustls::crypto::CryptoProvider;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -168,6 +169,10 @@ fn openaev_orchestrate(orchestrations: &mut Vec<JoinHandle<()>>) {
 
 #[tokio::main]
 async fn main() {
+    // Install the rustls CryptoProvider before any TLS client is created.
+    // Required since reqwest 0.13 switched from native-tls to rustls.
+    // Ignore error if a provider was already installed by another dependency.
+    let _ = CryptoProvider::install_default(rustls::crypto::aws_lc_rs::default_provider());
     // Initialize the global logging system
     init_logger();
     // Log the start


### PR DESCRIPTION
## Summary

After upgrading reqwest from 0.12 to 0.13 (PR #141), the TLS backend switched from `native-tls` (OpenSSL) to `rustls` 0.23. In minimal Docker/K8s containers, `rustls-platform-verifier` fails to auto-install a CryptoProvider, causing **all HTTPS requests to fail silently**.

### Symptoms
- `"Nothing to execute"` never appears (orchestration loop is dead)
- App runs but cannot communicate with OpenCTI/OpenAEV

### Fix
Adds explicit `CryptoProvider::install_default()` at the start of `main()` using `aws_lc_rs` (rustls's recommended default provider, already in the dependency tree).

### Changes
- `Cargo.toml` — add explicit `rustls` dependency with `aws_lc_rs` feature
- `src/main.rs` — install CryptoProvider before any HTTP client is created

Closes #140