### PR TITLE
chore: bump version to 3.260707.0 (#146)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3810,7 +3810,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtm-composer"
-version = "3.260609.0"
+version = "3.260707.0"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtm-composer"
-version = "3.260609.0"
+version = "3.260707.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
Closes #146

Bump xtm-composer version to 3.260707.0 for the 2026-07-07 release.