### PR TITLE
fix(openaev): avoid JSON parsing for push logs response (#133)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3810,7 +3810,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtm-composer"
-version = "3.260707.0"
+version = "3.260723.0"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtm-composer"
-version = "3.260707.0"
+version = "3.260723.0"
 edition = "2024"
 
 [dependencies]

--- a/src/api/openaev/api_handler.rs
+++ b/src/api/openaev/api_handler.rs
@@ -62,3 +62,71 @@ pub async fn handle_api_text_response(
         }
     }
 }
+
+pub async fn handle_api_status_response(
+    response: Result<reqwest::Response, reqwest::Error>,
+    operation_name: &str,
+) -> Option<()> {
+    match response {
+        Ok(resp) if resp.status().is_success() => Some(()),
+        Ok(resp) => {
+            error!(
+                status = resp.status().as_u16(),
+                "Failed to {}: non-success status code", operation_name
+            );
+            None
+        }
+        Err(err) => {
+            error!(
+                error = err.to_string(),
+                "Failed to {}, check your configuration", operation_name
+            );
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::handle_api_status_response;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    // Use no_proxy() to avoid picking up HTTP_PROXY env vars mutated by parallel tests.
+    fn no_proxy_client() -> reqwest::Client {
+        reqwest::Client::builder().no_proxy().build().unwrap()
+    }
+
+    async fn spawn_server_with_status(status_line: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((mut stream, _)) = listener.accept().await {
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf).await;
+                let response = format!("{}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n", status_line);
+                let _ = stream.write_all(response.as_bytes()).await;
+            }
+        });
+        format!("http://127.0.0.1:{}/", addr.port())
+    }
+
+    /// Regression test: the logs endpoint may return a non-JSON body (empty or plain text).
+    /// handle_api_status_response must succeed on any 2xx regardless of body content.
+    #[tokio::test]
+    async fn handle_api_status_response_accepts_non_json_success_body() {
+        let url = spawn_server_with_status("HTTP/1.1 200 OK").await;
+        let response = no_proxy_client().post(url).send().await;
+        let result = handle_api_status_response(response, "push logs for connector instance").await;
+        assert!(result.is_some(), "Expected Some(()) for a 200 response with non-JSON body");
+    }
+
+    #[tokio::test]
+    async fn handle_api_status_response_returns_none_on_error_status() {
+        let url = spawn_server_with_status("HTTP/1.1 500 Internal Server Error").await;
+        let response = no_proxy_client().post(url).send().await;
+        let result = handle_api_status_response(response, "push logs for connector instance").await;
+
+        assert!(result.is_none(), "Expected None for a 500 response");
+    }
+}

--- a/src/api/openaev/connector/post_logs.rs
+++ b/src/api/openaev/connector/post_logs.rs
@@ -1,6 +1,5 @@
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::JSON;
 use serde::Serialize;
-use crate::api::openaev::api_handler::handle_api_response;
+use crate::api::openaev::api_handler::handle_api_status_response;
 use crate::api::openaev::ApiOpenAEV;
 
 #[derive(Serialize)]
@@ -18,8 +17,8 @@ pub async fn add_logs(id: String, logs: Vec<String>, api: &ApiOpenAEV)-> Option<
         .send()
         .await;
 
-    // Discard the result
-    let _ = handle_api_response::<JSON>(
+    // OpenAEV may return an empty or text body for this endpoint; success status is enough.
+    let _ = handle_api_status_response(
         add_logs_response,
         "push logs for connector instance"
     ).await;


### PR DESCRIPTION
## Summary
OpenAEV `connector-instances/{id}/logs` may return an empty or non-JSON success body.
`patch_logs` was parsing this response as JSON, which produced parse errors even on successful requests.
## Changes
- switch `src/api/openaev/connector/post_logs.rs` to a status-only handler for log push responses
- add `handle_api_status_response` in `src/api/openaev/api_handler.rs`
- add regression tests for 2xx (success) and non-2xx (failure) behavior of the status-only handler
## Validation
- `cargo test api::openaev::api_handler::tests::handle_api_status_response_accepts_non_json_success_body -- --nocapture`
- `cargo test -- --nocapture`

Closes #133 