### PR TITLE
fix(kubernetes): self-heal deployments on immutable selector mismatch and stop parsing empty logs response (#151)

### DIFF
--- a/src/api/openaev/api_handler.rs
+++ b/src/api/openaev/api_handler.rs
@@ -35,6 +35,31 @@ where
     }
 }
 
+/// Handles API responses whose success body is empty (e.g. void endpoints).
+/// Only the HTTP status is checked; the body is discarded.
+pub async fn handle_api_empty_response(
+    response: Result<reqwest::Response, reqwest::Error>,
+    operation_name: &str,
+) -> Option<()> {
+    match response {
+        Ok(resp) if resp.status().is_success() => Some(()),
+        Ok(resp) => {
+            error!(
+                status = resp.status().as_u16(),
+                "Failed to {}: non-success status code", operation_name
+            );
+            None
+        }
+        Err(err) => {
+            error!(
+                error = err.to_string(),
+                "Failed to {}, check your configuration", operation_name
+            );
+            None
+        }
+    }
+}
+
 pub async fn handle_api_text_response(
     response: Result<reqwest::Response, reqwest::Error>,
     operation_name: &str,

--- a/src/api/openaev/api_handler.rs
+++ b/src/api/openaev/api_handler.rs
@@ -6,18 +6,20 @@ pub async fn handle_api_response<T>(
     operation_name: &str,
 ) -> Option<T>
 where
-    T: DeserializeOwned
+    T: DeserializeOwned,
 {
     match response {
-        Ok(resp) if resp.status().is_success() => {
-            match resp.json::<T>().await {
-                Ok(data) => Some(data),
-                Err(err) => {
-                    error!("Failed to parse JSON for {}: {}", operation_name, err.to_string());
-                    None
-                }
+        Ok(resp) if resp.status().is_success() => match resp.json::<T>().await {
+            Ok(data) => Some(data),
+            Err(err) => {
+                error!(
+                    "Failed to parse JSON for {}: {}",
+                    operation_name,
+                    err.to_string()
+                );
+                None
             }
-        }
+        },
         Ok(resp) => {
             error!(
                 status = resp.status().as_u16(),
@@ -35,15 +37,16 @@ where
     }
 }
 
-/// Handles API responses whose success body is empty (e.g. void endpoints).
-/// Only the HTTP status is checked; the body is discarded.
-pub async fn handle_api_empty_response(
+/// Handles API responses for acknowledgment-only endpoints whose success
+/// body is empty or non-JSON (e.g. void endpoints, plain-text acks).
+/// Only the HTTP status is checked; the body is drained and discarded.
+pub async fn handle_api_status_response(
     response: Result<reqwest::Response, reqwest::Error>,
     operation_name: &str,
 ) -> Option<()> {
     match response {
         Ok(resp) if resp.status().is_success() => {
-            // Drain the (empty) body so the underlying connection
+            // Drain the body so the underlying connection
             // can be returned to the pool and reused.
             let _ = resp.bytes().await;
             Some(())
@@ -70,12 +73,10 @@ pub async fn handle_api_text_response(
     operation_name: &str,
 ) -> Option<String> {
     match response {
-        Ok(resp) if resp.status().is_success() => {
-            resp.text().await.ok().or_else(|| {
-                error!("Failed to read response body for {}", operation_name);
-                None
-            })
-        }
+        Ok(resp) if resp.status().is_success() => resp.text().await.ok().or_else(|| {
+            error!("Failed to read response body for {}", operation_name);
+            None
+        }),
         Ok(resp) => {
             error!(
                 status = resp.status().as_u16(),
@@ -90,5 +91,71 @@ pub async fn handle_api_text_response(
             );
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::handle_api_status_response;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    // Use no_proxy() to avoid picking up HTTP_PROXY env vars mutated by parallel tests.
+    fn no_proxy_client() -> reqwest::Client {
+        reqwest::Client::builder().no_proxy().build().unwrap()
+    }
+
+    async fn spawn_server(status_line: &'static str, body: &'static str) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((mut stream, _)) = listener.accept().await {
+                let mut buf = [0u8; 4096];
+                let _ = stream.read(&mut buf).await;
+                let response = format!(
+                    "{}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    status_line,
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes()).await;
+            }
+        });
+        format!("http://127.0.0.1:{}/", addr.port())
+    }
+
+    /// Regression test: the logs endpoint may return an empty body on success.
+    /// handle_api_status_response must succeed on any 2xx regardless of body content.
+    #[tokio::test]
+    async fn handle_api_status_response_accepts_empty_success_body() {
+        let url = spawn_server("HTTP/1.1 200 OK", "").await;
+        let response = no_proxy_client().post(url).send().await;
+        let result = handle_api_status_response(response, "push logs for connector instance").await;
+        assert!(
+            result.is_some(),
+            "Expected Some(()) for a 200 response with an empty body"
+        );
+    }
+
+    /// Regression test: a non-JSON (plain text) success body must not be
+    /// treated as an error either.
+    #[tokio::test]
+    async fn handle_api_status_response_accepts_non_json_success_body() {
+        let url = spawn_server("HTTP/1.1 200 OK", "ack").await;
+        let response = no_proxy_client().post(url).send().await;
+        let result = handle_api_status_response(response, "push logs for connector instance").await;
+        assert!(
+            result.is_some(),
+            "Expected Some(()) for a 200 response with a non-JSON body"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_api_status_response_returns_none_on_error_status() {
+        let url = spawn_server("HTTP/1.1 500 Internal Server Error", "").await;
+        let response = no_proxy_client().post(url).send().await;
+        let result = handle_api_status_response(response, "push logs for connector instance").await;
+
+        assert!(result.is_none(), "Expected None for a 500 response");
     }
 }

--- a/src/api/openaev/api_handler.rs
+++ b/src/api/openaev/api_handler.rs
@@ -1,5 +1,5 @@
 use serde::de::DeserializeOwned;
-use tracing::error;
+use tracing::{debug, error};
 
 pub async fn handle_api_response<T>(
     response: Result<reqwest::Response, reqwest::Error>,
@@ -46,9 +46,15 @@ pub async fn handle_api_status_response(
 ) -> Option<()> {
     match response {
         Ok(resp) if resp.status().is_success() => {
-            // Drain the body so the underlying connection
-            // can be returned to the pool and reused.
-            let _ = resp.bytes().await;
+            // Drain the body so the underlying connection can be returned to
+            // the pool and reused. The 2xx status already acknowledged the
+            // operation, so a drain failure only affects connection reuse.
+            if let Err(err) = resp.bytes().await {
+                debug!(
+                    error = err.to_string(),
+                    "Failed to drain response body for {}", operation_name
+                );
+            }
             Some(())
         }
         Ok(resp) => {

--- a/src/api/openaev/api_handler.rs
+++ b/src/api/openaev/api_handler.rs
@@ -42,7 +42,12 @@ pub async fn handle_api_empty_response(
     operation_name: &str,
 ) -> Option<()> {
     match response {
-        Ok(resp) if resp.status().is_success() => Some(()),
+        Ok(resp) if resp.status().is_success() => {
+            // Drain the (empty) body so the underlying connection
+            // can be returned to the pool and reused.
+            let _ = resp.bytes().await;
+            Some(())
+        }
         Ok(resp) => {
             error!(
                 status = resp.status().as_u16(),

--- a/src/api/openaev/connector/post_logs.rs
+++ b/src/api/openaev/connector/post_logs.rs
@@ -1,6 +1,5 @@
-use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::JSON;
 use serde::Serialize;
-use crate::api::openaev::api_handler::handle_api_response;
+use crate::api::openaev::api_handler::handle_api_empty_response;
 use crate::api::openaev::ApiOpenAEV;
 
 #[derive(Serialize)]
@@ -18,8 +17,9 @@ pub async fn add_logs(id: String, logs: Vec<String>, api: &ApiOpenAEV)-> Option<
         .send()
         .await;
 
-    // Discard the result
-    let _ = handle_api_response::<JSON>(
+    // The OpenAEV logs endpoint returns an empty body on success:
+    // only check the HTTP status instead of parsing JSON.
+    let _ = handle_api_empty_response(
         add_logs_response,
         "push logs for connector instance"
     ).await;

--- a/src/api/openaev/connector/post_logs.rs
+++ b/src/api/openaev/connector/post_logs.rs
@@ -1,28 +1,29 @@
-use serde::Serialize;
-use crate::api::openaev::api_handler::handle_api_empty_response;
 use crate::api::openaev::ApiOpenAEV;
+use crate::api::openaev::api_handler::handle_api_status_response;
+use serde::Serialize;
 
 #[derive(Serialize)]
 struct InstanceConnectorLogsInput {
     connector_instance_logs: Vec<String>,
 }
 
-pub async fn add_logs(id: String, logs: Vec<String>, api: &ApiOpenAEV)-> Option<String> {
-    let logs_input = InstanceConnectorLogsInput{
-        connector_instance_logs: logs
+pub async fn add_logs(id: String, logs: Vec<String>, api: &ApiOpenAEV) -> Option<String> {
+    let logs_input = InstanceConnectorLogsInput {
+        connector_instance_logs: logs,
     };
     let settings = crate::settings();
-    let add_logs_response = api.post(&format!("/xtm-composer/{}/connector-instances/{}/logs",settings.manager.id, id))
+    let add_logs_response = api
+        .post(&format!(
+            "/xtm-composer/{}/connector-instances/{}/logs",
+            settings.manager.id, id
+        ))
         .json(&logs_input)
         .send()
         .await;
 
-    // The OpenAEV logs endpoint returns an empty body on success:
+    // OpenAEV may return an empty or non-JSON body for this endpoint:
     // only check the HTTP status instead of parsing JSON.
-    let _ = handle_api_empty_response(
-        add_logs_response,
-        "push logs for connector instance"
-    ).await;
+    let _ = handle_api_status_response(add_logs_response, "push logs for connector instance").await;
 
     Some(id)
 }

--- a/src/api/openaev/connector/post_logs.rs
+++ b/src/api/openaev/connector/post_logs.rs
@@ -22,8 +22,10 @@ pub async fn add_logs(id: String, logs: Vec<String>, api: &ApiOpenAEV) -> Option
         .await;
 
     // OpenAEV may return an empty or non-JSON body for this endpoint:
-    // only check the HTTP status instead of parsing JSON.
-    let _ = handle_api_status_response(add_logs_response, "push logs for connector instance").await;
-
-    Some(id)
+    // only check the HTTP status instead of parsing JSON. Propagate the
+    // outcome so callers can detect delivery failures, like the OpenCTI
+    // logs push does.
+    handle_api_status_response(add_logs_response, "push logs for connector instance")
+        .await
+        .map(|_| id)
 }

--- a/src/orchestrator/kubernetes/kubernetes.rs
+++ b/src/orchestrator/kubernetes/kubernetes.rs
@@ -313,6 +313,16 @@ impl KubeOrchestrator {
         patch_value
     }
 
+    /// Returns true when a 422 rejection is caused by the immutable
+    /// `spec.selector` no longer matching the new template labels (e.g.
+    /// "`selector` does not match template `labels`" or "field is immutable").
+    /// Other 422 validation errors must not trigger the self-heal deletion.
+    pub fn is_selector_immutability_conflict(message: &str) -> bool {
+        message.contains("selector")
+            && (message.contains("does not match template")
+                || message.contains("field is immutable"))
+    }
+
     // Enrich container with pod information
     fn enrich_container_from_pod(&self, container: &mut OrchestratorContainer, pod: Pod) {
         let container_status = pod
@@ -421,16 +431,20 @@ impl Orchestrator for KubeOrchestrator {
             .await;
         match deployment_result {
             Ok(deployment) => Some(KubeOrchestrator::from_deployment(deployment)),
-            Err(kube::Error::Api(ae)) if ae.code == 422 => {
+            Err(kube::Error::Api(ae))
+                if ae.code == 422 && Self::is_selector_immutability_conflict(&ae.message) =>
+            {
                 // The deployment was created with a label set that no longer matches
                 // the current configuration (spec.selector is immutable), so every
                 // update attempt is rejected and the composer would retry forever.
                 // Self-heal by deleting the stale deployment: the next orchestration
                 // cycle redeploys it with a coherent selector/labels pair.
+                // Other 422 validation errors fall through to the generic error
+                // logging below instead of deleting a possibly-healthy deployment.
                 warn!(
                     name = name,
                     error = ae.to_string(),
-                    "Deployment update rejected as invalid, deleting stale deployment for redeploy"
+                    "Deployment update rejected on immutable selector mismatch, deleting stale deployment for redeploy"
                 );
                 match self
                     .deployments

--- a/src/orchestrator/kubernetes/kubernetes.rs
+++ b/src/orchestrator/kubernetes/kubernetes.rs
@@ -421,6 +421,34 @@ impl Orchestrator for KubeOrchestrator {
             .await;
         match deployment_result {
             Ok(deployment) => Some(KubeOrchestrator::from_deployment(deployment)),
+            Err(kube::Error::Api(ae)) if ae.code == 422 => {
+                // The deployment was created with a label set that no longer matches
+                // the current configuration (spec.selector is immutable), so every
+                // update attempt is rejected and the composer would retry forever.
+                // Self-heal by deleting the stale deployment: the next orchestration
+                // cycle redeploys it with a coherent selector/labels pair.
+                warn!(
+                    name = name,
+                    error = ae.to_string(),
+                    "Deployment update rejected as invalid, deleting stale deployment for redeploy"
+                );
+                match self
+                    .deployments
+                    .delete(name.as_str(), &DeleteParams::default())
+                    .await
+                {
+                    Ok(_) => info!(
+                        name = name,
+                        "Stale deployment deleted, it will be redeployed on the next cycle"
+                    ),
+                    Err(err) => error!(
+                        name = name,
+                        error = err.to_string(),
+                        "Failed to delete stale deployment"
+                    ),
+                }
+                None
+            }
             Err(kube::Error::Api(ae)) => {
                 error!(error = ae.to_string(), "Kubernetes update api error");
                 None

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -234,6 +234,44 @@ mod tests {
     }
 
     #[test]
+    fn selector_immutability_conflict_matches_kubernetes_message() {
+        // Real message emitted by the Kubernetes API when the immutable
+        // spec.selector no longer matches the new template labels.
+        let mismatch = "Deployment.apps \"nmap--the-network-mapper-83257074\" is invalid: \
+            spec.template.metadata.labels: Invalid value: \
+            map[string]string{\"app\":\"connector\"}: \
+            `selector` does not match template `labels`";
+        assert!(KubeOrchestrator::is_selector_immutability_conflict(
+            mismatch
+        ));
+
+        let immutable = "Deployment.apps \"x\" is invalid: spec.selector: \
+            Invalid value: v1.LabelSelector{...}: field is immutable";
+        assert!(KubeOrchestrator::is_selector_immutability_conflict(
+            immutable
+        ));
+    }
+
+    #[test]
+    fn selector_immutability_conflict_ignores_other_422_errors() {
+        // Unrelated validation failures must not trigger the self-heal
+        // deletion of a possibly-healthy deployment.
+        let bad_env = "Deployment.apps \"x\" is invalid: \
+            spec.template.spec.containers[0].env[0].name: Invalid value: \
+            \"BAD NAME\": a valid environment variable name must consist of...";
+        assert!(!KubeOrchestrator::is_selector_immutability_conflict(
+            bad_env
+        ));
+
+        let bad_quantity = "Deployment.apps \"x\" is invalid: \
+            spec.template.spec.containers[0].resources.limits[memory]: \
+            Invalid value: \"10Gx\": unable to parse quantity's suffix";
+        assert!(!KubeOrchestrator::is_selector_immutability_conflict(
+            bad_quantity
+        ));
+    }
+
+    #[test]
     fn build_refresh_patch_strips_selector() {
         // This test calls KubeOrchestrator::build_refresh_patch directly.
         use k8s_openapi::api::apps::v1::{Deployment, DeploymentSpec};


### PR DESCRIPTION
## Summary

Closes #151
Closes #133

Fixes the two reconcile-loop bugs described in #151, observed on an OpenAEV staging platform:

- **Kubernetes refresh self-heal on immutable selector mismatch**: when a deployment was created with an older label set and the current configuration produces different labels, `spec.selector` (immutable) can no longer match the new template labels, so every refresh is rejected with HTTP 422 and the composer retried forever (every cycle). The refresh path now detects this specific rejection and self-heals: it deletes the stale deployment and lets the next orchestration cycle redeploy it with a coherent selector/labels pair - the same philosophy as the existing stale-name cleanup. The guard is narrowed to selector/labels immutability conflicts only (`is_selector_immutability_conflict` inspects the API error message); any other 422 validation error falls through to the normal error logging path instead of deleting a possibly-healthy deployment.
- **Stop parsing the empty logs-push response as JSON**: the OpenAEV `POST .../connector-instances/{id}/logs` endpoint returns an empty or non-JSON body on success, but `add_logs` parsed it through `handle_api_response::<JSON>`, logging `Failed to parse JSON for push logs...` on every successful push. Added `handle_api_status_response` (status-only check, drains the body so the connection can be reused by the pool, drain failures logged at debug) and switched the logs push to it. `add_logs` now propagates the outcome (`None` on transport failure or non-2xx) instead of always returning `Some(id)`, mirroring the OpenCTI logs push.

The logs-push part supersedes #150 by @mariot, which solved the same issue (#133): this PR adopts its `handle_api_status_response` naming and ports its regression tests (2xx with empty and non-JSON bodies succeed, non-2xx returns None), with co-author credit on the corresponding commit. On top of #150, this PR also drains the success body so the reqwest connection returns to the pool.

## Test plan

- [x] `cargo test` - 41 passed, 0 failed (2 new unit tests for the selector-mismatch message guard, 3 regression tests for the status-only handler)
- [x] `cargo check` clean
- [x] New code rustfmt-clean (pre-existing fmt drift in untouched regions left as is; `post_logs.rs` fully formatted since this PR touches it)
- [ ] Staging validation: deployment previously stuck in the `Refreshing` / `Kubernetes update api error` loop (`nmap--the-network-mapper-83257074...`) gets deleted and redeployed with current labels on the next cycle
- [ ] Staging validation: no more `Failed to parse JSON for push logs` errors in composer logs
