### PR TITLE
chore: bump version to 3.260728.0 (#153)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3810,7 +3810,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtm-composer"
-version = "3.260707.0"
+version = "3.260728.0"
 dependencies = [
  "aes-gcm",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xtm-composer"
-version = "3.260707.0"
+version = "3.260728.0"
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
## Summary

Closes #153

Bump xtm-composer version to 3.260728.0 for the 2026-07-28 release. This release ships the Kubernetes selector-mismatch self-heal and the OpenAEV logs-push fixes from #152 (closes #151 and #133).

## Test plan

- [x] `cargo check` clean (Cargo.lock refreshed by cargo itself)
- [x] Two-line diff (Cargo.toml + Cargo.lock), same shape as the previous bump (#147)
