### PR TITLE
ci(test): integrate codecov coverage upload (#100)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -16,6 +19,9 @@ jobs:
 
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Cache Rust dependencies
         uses: actions/cache@v4
@@ -28,6 +34,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
-      - name: Run tests
-        run: cargo test
+      - name: Run tests with coverage
+        run: cargo llvm-cov --workspace --all-features --lcov --output-path lcov.info
 
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() && hashFiles('lcov.info') != '' }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./lcov.info
+          fail_ci_if_error: false
+          verbose: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
 
 permissions:
   contents: read
-
+  id-token: write
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+# Codecov configuration for CI coverage reporting and patch-quality gating.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        target: 80%
+        threshold: 0%
+        informational: false


### PR DESCRIPTION
### Proposed changes
* Add coverage generation to the test workflow using cargo-llvm-cov and emit an lcov.info report.
* Upload generated coverage to Codecov from CI using codecov/codecov-action@v5.
* Keep CI permissions minimal while enabling public-repo tokenless/OIDC upload support via `id-token: write`.
* Add `codecov.yml` with patch status gating to enforce a minimum 80% coverage target on new code.
* CODECOV_TOKEN is required for private-repository uploads; for public repositories, Codecov can use OIDC/tokenless upload.

### Related issues
* closes #100
* closes #101